### PR TITLE
Bump Go rules to work with up-to-date bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    commit = "8b2c913a841c7ea4c3f0514fbc8f132f5dd03dfd",
+    tag = "0.4.0",
 )
 
 load('@io_bazel_rules_go//go:def.bzl', 'go_repositories')
@@ -14,7 +14,7 @@ go_repositories()
 git_repository(
     name = "io_bazel_rules_closure",
     remote = "https://github.com/bazelbuild/rules_closure.git",
-    tag = "0.1.0",
+    tag = "0.4.0",
 )
 
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")


### PR DESCRIPTION
Building with latest bazel results in `HOST_CFG` related failures similarly to:

   https://github.com/tensorflow/tensorflow/issues/4371

Merely bumping causes it to work.